### PR TITLE
Fix `move` calls that are not from `step`

### DIFF
--- a/widowx_envs/widowx_controller/src/widowx_controller/custom_gripper_controller.py
+++ b/widowx_envs/widowx_controller/src/widowx_controller/custom_gripper_controller.py
@@ -59,6 +59,9 @@ class GripperController(GripperControllerBase):
 
     def get_gripper_pos(self):
         with self._joint_lock:
+            if 'left_finger' not in self._angles:
+                print(" WARNING!! left_finger should be avail in gripper")
+                return 0.0
             return self._angles['left_finger']
 
     def _joint_callback(self, msg):

--- a/widowx_envs/widowx_controller/src/widowx_controller/widowx_controller.py
+++ b/widowx_envs/widowx_controller/src/widowx_controller/widowx_controller.py
@@ -92,7 +92,7 @@ class ModifiedInterbotixArmXSInterface(InterbotixArmXSInterface):
 
     def set_ee_pose_matrix_fast(self, T_sd, custom_guess=None, execute=True):
         """
-        this version of set_ee_pose_matrix does not set the velocity profie registers in the servos and therefore runs faster
+        this version of set_ee_pose_matrix does not set the velocity profile registers in the servos and therefore runs faster
         """
         if (custom_guess is None):
             initial_guesses = self.initial_guesses
@@ -201,13 +201,14 @@ class WidowX_Controller(RobotControllerBase):
     def set_moving_time(self, moving_time):
         self.bot.arm.set_trajectory_time(moving_time=moving_time*1.25, accel_time=moving_time * 0.5)
 
-    def move_to_eep(self, target_pose, duration=1.5, blocking=True, check_effort=True):
+    def move_to_eep(self, target_pose, duration=1.5, blocking=True, check_effort=True, step=True):
         try:
-            if not blocking:
+            if step and not blocking:
+                # this is a call from the `step` function so we use a custom faster way to set the ee pose
                 solution, success = self.bot.arm.set_ee_pose_matrix_fast(target_pose, custom_guess=self.get_joint_angles(), execute=True)
             else:
                 solution, success = self.bot.arm.set_ee_pose_matrix(target_pose, custom_guess=self.get_joint_angles(),
-                                                                moving_time=duration, accel_time=duration * 0.45)
+                                        moving_time=duration, accel_time=duration * 0.45, blocking=blocking)
             
             self.des_joint_angles = solution
             

--- a/widowx_envs/widowx_envs/widowx_env_service.py
+++ b/widowx_envs/widowx_envs/widowx_env_service.py
@@ -196,7 +196,8 @@ class WidowXActionServer():
             self.bridge_env.controller().move_to_eep(
                 eep,
                 duration=payload["duration"],
-                blocking=payload["blocking"]
+                blocking=payload["blocking"],
+                step=False
             )
             self.bridge_env._reset_previous_qpos()
         except Environment_Exception as e:
@@ -215,7 +216,7 @@ class WidowXActionServer():
         # self.bridge_env.controller().move_to_neutral(duration=1.0)
         # self.bridge_env.controller().open_gripper()
         self.bridge_env.reset()
-        # self.bridge_env.start() # NOTE: seems to reset the duration=0, bad
+        self.bridge_env.start()
         return WidowXStatus.SUCCESS
 
 ##############################################################################


### PR DESCRIPTION
This fixes an issue where calls to `widowx_client.move` (for example to set the goal or initial gripper position) would sometimes cause the arm to move very fast. This was caused by using `move_to_eep` with `blocking=False`. When `blocking=False` the `move_to_eep` function uses a custom implementation of `set_ee_pose_matrix` (original is [here](https://github.com/Interbotix/interbotix_ros_toolboxes/blob/main/interbotix_xs_toolbox/interbotix_xs_modules/src/interbotix_xs_modules/arm.py#L189)) that does not set the velocity profiles and ignores the move duration that is passed in (in order to execute the action faster). Instead the velocity profiles get set only once in the call to `bridge_env.start`. The overall effect was that `widowx_client.move` would cause the robot to move with the very small duration used for executing actions with `step` (thus moving extremely fast in order to cover the large distance need to move to the initial/goal gripper postion). 

To fix this I did a few things: 
- Add back the `bridge_env.start` call in the `reset` function. This will make sure the velocity profiles are set correctly for non-blocking control.
- Modify the `move_to_eep` function to take in a new argument `step` that determines whether this call is coming from the `step` function or whether it's coming from the `move` function. If the call comes from `step` we use the custom implementation of `set_ee_pose_matrix` that ignores the `duration`. Otherwise we use the default `set_ee_pose_matrix` that respects the `duration` and sets the velocity profiles accordingly. 